### PR TITLE
Add new test for OLE provider initialization error

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -3,6 +3,7 @@
 Fatal error:	0	PHP	Low	Certain
 \.php:[0-9]+	0	PHP	Low	Certain
 \[(ODBC SQL Server Driver|SQL Server|ODBC Driver Manager)\]	0	Microsoft SQL Server	Low	Certain
+Cannot initialize the data source object of OLE DB provider "[\w]*" for linked server "[\w]*"	0	Microsoft SQL Server	Low	Certain
 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near	0	MySQL	Medium	Certain
 Illegal mix of collations \([\w\s\,]+\) and \([\w\s\,]+\) for operation	0	MySQL	Medium	Certain
 \.java:[0-9]+	0	Java	Low	Certain

--- a/src/test/resources/burp/testResponse.txt
+++ b/src/test/resources/burp/testResponse.txt
@@ -2,6 +2,7 @@ Fatal error: Call to a member function getId() on a non-object in /var/www/docro
 <b>Warning</b>: Invalid argument supplied for foreach() in <b>/home/content/.../admin/model/report/sale.php</b> on line <b>87</b>
 Fatal error: Undefined class constant 'PRODUCT' in 
 OLE DB provider "MSDASQL" for linked server "INFORMIX_LIBRARY" returned message "[Microsoft][ODBC Driver Manager] Driver's SQLSetConnectAttr failed".
+Cannot initialize the data source object of OLE DB provider "MSDASQL" for linked server "INFORMIX_LIBRARY".
 You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'Details (title, first, last, NRIC, po' at line 1
 <p>Illegal mix of collations (latin1_swedish_ci ,IMPLICIT) and (utf8_general_ci ,COERCIBLE) for operation ’=’</p>
 [SEVERE] at net.minecraft.server.World.tickEntities(World.java:1146)


### PR DESCRIPTION
Detects error messages like: 

Cannot initialize the data source object of OLE DB provider "MSDASQL" for linked server "INFORMIX_LIBRARY".