### PR TITLE
Use latest version of utils

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
         <dependency>
             <groupId>com.codemagi</groupId>
             <artifactId>burp-suite-utils</artifactId>
-            <version>LATEST</version>
+            <version>1.2.5</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
Provides for better combining of offsets when matches overlap. See: https://github.com/augustd/burp-suite-software-version-checks/pull/95/files