### PR TITLE
Add two patterns for JDBC+MSSSQL error messages

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -35,6 +35,8 @@ java.io.FileNotFoundException:	0	Java	Low	Certain
 JBWEB[0-9]{6}:	0	JBoss	Low	Firm
 ((dn|dc|cn|ou|uid|o|c)=[\w\d]*,\s?){2,}	0	LDAP	Low	Firm
 DB Error:	0	Maria	Low	Certain	0
+com.microsoft.sqlserver.jdbc.SQLServerException	0	Microsoft SQL Server	High	Firm
+Invalid object name .+ bad SQL grammar	0	Microsoft SQL Server	High	Firm
 \[(ODBC SQL Server Driver|SQL Server|ODBC Driver Manager)\]	0	Microsoft SQL Server	Low	Certain
 Unclosed quotation mark	0	Microsoft SQL Server	Low	Certain	1
 warning.*mssql_.*	0	Microsoft SQL Server	Low	Certain	0
@@ -76,7 +78,7 @@ valid PostgreSQL result	0	PostgreSQL	Low	Certain	0
 Npgsql\.	0	PostgreSQL	Low	Certain	0
 org\.postgresql\.util\.PSQLException	0	PostgreSQL	Low	Certain	0
 Traceback \(most recent call last\):	0	Python	Low	Certain
-File \"[A-Za-z0-9\-_\./]*\", line [0-9]+, in	0	Python	Low	Certain
+File \"[A-Za-z0-9\-_\.\]*\", line [0-9]+, in	0	Python	Low	Certain
 NameError:	0	Python	Low	Certain
 ImportError:	0	Python	Low	Certain
 IndentationError:	0	Python	Low	Certain

--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -35,7 +35,7 @@ java.io.FileNotFoundException:	0	Java	Low	Certain
 JBWEB[0-9]{6}:	0	JBoss	Low	Firm
 ((dn|dc|cn|ou|uid|o|c)=[\w\d]*,\s?){2,}	0	LDAP	Low	Firm
 DB Error:	0	Maria	Low	Certain	0
-com.microsoft.sqlserver.jdbc.SQLServerException	0	Microsoft SQL Server	High	Firm
+com\.microsoft\.sqlserver\.jdbc\.SQLServerException	0	Microsoft SQL Server	High	Firm
 Invalid object name .+ bad SQL grammar	0	Microsoft SQL Server	High	Firm
 \[(ODBC SQL Server Driver|SQL Server|ODBC Driver Manager)\]	0	Microsoft SQL Server	Low	Certain
 Unclosed quotation mark	0	Microsoft SQL Server	Low	Certain	1
@@ -52,8 +52,8 @@ Error: Unknown column	0	MySQL	Low	Certain	0
 Warning.*mysql_.*	0	MySQL	Low	Certain	0
 valid MySQL result	0	MySQL	Low	Certain	0
 MySqlClient\.	0	MySQL	Low	Certain	0
-com\.mysql\.jdbc\.exceptions	0	MySQL	Low	Certain	0
-warning mysql_	0	MySQL	Low	Certain	0
+com\.mysql\.jdbc\.exce/tions	0	MySQL	Low	Certain	0
+warning mysql_		MySQL	Low	Certain	0
 1062 Duplicate entry	0	MYSQL	Low	Certain	0
 client intended to address	0	NGINX Server	Low	Firm
 could not build optimal proxy_headers_hash	0	NGINX Server	Low	Firm

--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -78,7 +78,7 @@ valid PostgreSQL result	0	PostgreSQL	Low	Certain	0
 Npgsql\.	0	PostgreSQL	Low	Certain	0
 org\.postgresql\.util\.PSQLException	0	PostgreSQL	Low	Certain	0
 Traceback \(most recent call last\):	0	Python	Low	Certain
-File \"[A-Za-z0-9\-_\.\]*\", line [0-9]+, in	0	Python	Low	Certain
+File \"[A-Za-z0-9\-_\./]*\", line [0-9]+, in	0	Python	Low	Certain
 NameError:	0	Python	Low	Certain
 ImportError:	0	Python	Low	Certain
 IndentationError:	0	Python	Low	Certain


### PR DESCRIPTION
... which I encountered during a pen test. A case of SQL Injection. Thus it is labled as high. Firm indicates that it needs to be manually confirmed. In this case it DID NOT work (confirmed with sqlmap and somehow with the client).

I spotted them but not using burp-suite-error-message-checks

message was

```
{"msg":"\n### Error querying database.  Cause: com.microsoft.sqlserver.jdbc.SQLServerException: Invalid object name 'user'.\n### The error may exist in REDACTED.java (best guess)\n### The error may involve defaultParameterMap\n### The error occurred while setting parameters\n### SQL: SELECT  id,account,password,is_active,create_time,update_time,failed_numbers  FROM [user]     WHERE (account = ?)\n### Cause: com.microsoft.sqlserver.jdbc.SQLServerException: Invalid object name 'user'.\n; bad SQL grammar []; nested exception is com.microsoft.sqlserver.jdbc.SQLServerException: Invalid object name 'user'.","code":500}
```

fixes #66

The diff on two other lines I noticed seemed tohave different line endings. The diff is fine with ``git diff -w`` .