### PR TITLE
Add two patterns for JDBC+MSSSQL error messages

### DIFF
--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -35,6 +35,8 @@ java.io.FileNotFoundException:	0	Java	Low	Certain
 JBWEB[0-9]{6}:	0	JBoss	Low	Firm
 ((dn|dc|cn|ou|uid|o|c)=[\w\d]*,\s?){2,}	0	LDAP	Low	Firm
 DB Error:	0	Maria	Low	Certain	0
+com\.microsoft\.sqlserver\.jdbc\.SQLServerException	0	Microsoft SQL Server	High	Firm
+Invalid object name .+ bad SQL grammar	0	Microsoft SQL Server	High	Firm
 \[(ODBC SQL Server Driver|SQL Server|ODBC Driver Manager)\]	0	Microsoft SQL Server	Low	Certain
 Unclosed quotation mark	0	Microsoft SQL Server	Low	Certain	1
 warning.*mssql_.*	0	Microsoft SQL Server	Low	Certain	0

--- a/src/main/resources/burp/match-rules.tab
+++ b/src/main/resources/burp/match-rules.tab
@@ -18,7 +18,7 @@ db2_\w+\(	0	DB2	Low	Certain	0
 \[function.ibase.query\]	0	Firebird	Low	Certain	0
 Dynamic SQL Error	0	Firebird	Low	Certain	0
 Warning.*ibase_.*	0	Firebird	Low	Certain	0
-\.groovy:[0-9]+	0	Groovy	High	Certain
+\.groovy:[0-9]+	0	Groovy	Low	Certain
 org\.hsqldb\.jdbc	0	HyperSQL	Low	Certain	0
 Exception.*Informix	0	Informix	Low	Certain	0
 Warning.*ingre_	0	Ingres DB	Low	Certain	0
@@ -28,15 +28,15 @@ HSQLDB	0	Ingres DB	Low	Certain	0
 \.java:[0-9]+	0	Java	Low	Certain
 \.java\((Inlined )?Compiled Code\)	0	Java	Low	Certain	2
 \.invoke\(Unknown Source\)	0	Java	Low	Certain
-nested exception is	0	Java	Low	Firm
+nested exception is	0	Java	Low	Firm	2
 java\.lang\.([A-Za-z0-9_]*)Exception	0	Java	Medium	Firm	5
 java.io.FileNotFoundException:	0	Java	Low	Certain
 \.js:[0-9]+:[0-9]+	0	Javascript	Low	Certain
 JBWEB[0-9]{6}:	0	JBoss	Low	Firm
 ((dn|dc|cn|ou|uid|o|c)=[\w\d]*,\s?){2,}	0	LDAP	Low	Firm
 DB Error:	0	Maria	Low	Certain	0
-com\.microsoft\.sqlserver\.jdbc\.SQLServerException	0	Microsoft SQL Server	High	Firm
-Invalid object name .+ bad SQL grammar	0	Microsoft SQL Server	High	Firm
+com\.microsoft\.sqlserver\.jdbc\.SQLServerException	0	Microsoft SQL Server	Medium	Certain	3
+Invalid object name .+ bad SQL grammar	0	Microsoft SQL Server	Medium	Certain
 \[(ODBC SQL Server Driver|SQL Server|ODBC Driver Manager)\]	0	Microsoft SQL Server	Low	Certain
 Unclosed quotation mark	0	Microsoft SQL Server	Low	Certain	1
 warning.*mssql_.*	0	Microsoft SQL Server	Low	Certain	0

--- a/src/test/resources/burp/testResponse.txt
+++ b/src/test/resources/burp/testResponse.txt
@@ -68,3 +68,4 @@ could not build optimal proxy_headers_hash, you should increase either proxy_hea
 E QUERY [thread1] SyntaxError: invalid object initializer
 2016-10-26T19:34:34.886-0400 E QUERY    [thread1] SyntaxError: missing ; before statement @(shell eval):1:5
 uncaught exception: out of memory
+{"msg":"\n### Error querying database.  Cause: com.microsoft.sqlserver.jdbc.SQLServerException: Invalid object name 'user'.\n### The error may exist in REDACTED.java (best guess)\n### The error may involve defaultParameterMap\n### The error occurred while setting parameters\n### SQL: SELECT  id,account,password,is_active,create_time,update_time,failed_numbers  FROM [user]     WHERE (account = ?)\n### Cause: com.microsoft.sqlserver.jdbc.SQLServerException: Invalid object name 'user'.\n; bad SQL grammar []; nested exception is com.microsoft.sqlserver.jdbc.SQLServerException: Invalid object name 'user'.","code":500}


### PR DESCRIPTION
... which I encountered during a pen test. That was a case of SQL Injection. Thus it is labled as high. Firm indicates that it needs to be manually confirmed. In this case retrieving db contents DID NOT work (confirmed with sqlmap and somehow with the client).

I spotted them but not using burp-suite-error-message-checks. So I thought to add this here.

The message was

```
{"msg":"\n### Error querying database.  Cause: com.microsoft.sqlserver.jdbc.SQLServerException: Invalid object name 'user'.\n### The error may exist in REDACTED.java (best guess)\n### The error may involve defaultParameterMap\n### The error occurred while setting parameters\n### SQL: SELECT  id,account,password,is_active,create_time,update_time,failed_numbers  FROM [user]     WHERE (account = ?)\n### Cause: com.microsoft.sqlserver.jdbc.SQLServerException: Invalid object name 'user'.\n; bad SQL grammar []; nested exception is com.microsoft.sqlserver.jdbc.SQLServerException: Invalid object name 'user'.","code":500}
```

This PR fixes #66

The diff on other line seemed to have different line endings. The diff is fine with ``git diff -w`` .